### PR TITLE
fix typo

### DIFF
--- a/go/design/error_4.go
+++ b/go/design/error_4.go
@@ -74,7 +74,7 @@ func (c *client) TypeAsContext() {
 // named Temporary then this is what we want. We get to stay decoupled and continue to work at the
 // interface level.
 type temporary interface {
-	Temporary() bool
+	temporary() bool
 }
 
 // BehaviorAsContext shows how to check for the behavior of an interface

--- a/go/design/error_4.go
+++ b/go/design/error_4.go
@@ -71,7 +71,7 @@ func (c *client) TypeAsContext() {
 
 // temporary is declared to test for the existence of the method coming from the net package.
 // Because Temporary is the only behavior we care about. If the concrete type has the method
-// named temporary then this is what we want. We get to stay decoupled and continue to work at the
+// named Temporary then this is what we want. We get to stay decoupled and continue to work at the
 // interface level.
 type temporary interface {
 	Temporary() bool
@@ -109,5 +109,5 @@ func (c *client) BehaviorAsContext() {
 
 // Lesson:
 // Thank to Go Implicit Conversion.
-// We can maintain a level of decopling by creating an interface with methods or behaviors that we only want,
+// We can maintain a level of decoupling by creating an interface with methods or behaviors that we only want,
 // and use it instead of concrete type for type assertion switch. 


### PR DESCRIPTION
I guess the method name has to be an exported version and a typo.